### PR TITLE
Propagate preventDefault() to original event

### DIFF
--- a/src/jquery.finger.js
+++ b/src/jquery.finger.js
@@ -99,7 +99,8 @@
 			timeStamp = event.timeStamp || +new Date(),
 			f = $.data(this, namespace),
 			dt = timeStamp - data.start.time,
-			evtName;
+			evtName,
+			fingerEvent;
 
 		// always clears press timeout
 		clearTimeout(data.timeout);
@@ -119,7 +120,13 @@
 			data.move.end = true;
 		}
 
-		$.event.trigger($.Event(evtName, data.move), null, event.target);
+		fingerEvent = $.Event(evtName, data.move);
+		$.event.trigger(fingerEvent, null, event.target);
+		
+		// prevent default on the original?
+		if (fingerEvent.isDefaultPrevented()) {
+			event.preventDefault();
+		}
 
 		$.event.remove(this, moveEvent + '.' + namespace, moveHandler);
 		$.event.remove(this, stopEvent + '.' + namespace, stopHandler);


### PR DESCRIPTION
This is related to #4. If I have a custom event handler for `tap`, `doubletap`, `flick`, `drag`, etc. that calls `event.preventDefault()`, then Finger should call `event.preventDefault()` on the **original** event that triggered `stopHandler()`.

This allows you to prevent the default behavior (native clicks, text selection, etc.) but _only_ in certain cases (i.e., where a Finger event was handled and that handler prevented the default action).

Since this only affects cases where the `tap` (or whatever) handler calls `event.preventDefault()`, I don't think this even needs an option in Finger (obviously, if you want the default behavior, you should avoid calling `event.preventDefault()`).
