### PR TITLE
Propagate preventDefault() to original event, take 2

### DIFF
--- a/src/jquery.finger.js
+++ b/src/jquery.finger.js
@@ -99,7 +99,8 @@
 			timeStamp = event.timeStamp || +new Date(),
 			f = $.data(this, namespace),
 			dt = timeStamp - data.start.time,
-			evtName;
+			evtName,
+			fingerEvent;
 
 		// always clears press timeout
 		clearTimeout(data.timeout);


### PR DESCRIPTION
See #4 and #6. The purpose is to prevent **some** of the browser's default behavior (specifically the buggy `click` events) while still allowing scrolling, zooming, etc.

If `event.preventDefault()` and friends are called in the custom handler, they will be propagated to the original stop event. For API completeness, there's also an option `preventDefaultEnd` to control this behavior via event data.
