### PR TITLE
Make sure we have an ending drag event when flick is fired.

### DIFF
--- a/src/jquery.finger.js
+++ b/src/jquery.finger.js
@@ -160,9 +160,12 @@
 		else {
 			// ensure last target is set the initial one
 			event.target = start.target;
-			if (dt < Finger.flickDuration) trigger(event, 'flick');
 			move.end = true;
 			evtName = 'drag';
+			if (dt < Finger.flickDuration) {
+				trigger(event, evtName);
+				trigger(event, 'flick');
+			}
 		}
 
 		trigger(event, evtName, true);


### PR DESCRIPTION
When a flick event is fired the previous drag event does not set end as true, so this fires another drag event prior to the flick to ensure we have an end drag event.

I've need this when combining flick and drag events on the same elements. 

Better solution maybe to understand when the trigger on 168 wasn't actually firing for drag, but i've not had chance to really read the JS, so this is just a quick-cheap fix.
