### PR TITLE
Browserify can't find package when require('jquery.finger')

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "Shims",
     "Utilities"
   ],
+  "main": "dist/jquery.finger.js",
   "jam": {
     "main": "dist/jquery.finger.js",
     "include": [


### PR DESCRIPTION
Because "main" key in package.json or index.js in repository root doesn't exists. https://github.com/substack/node-browserify#packagejson