### PR TITLE
Ignore non-left mouse clicks

### DIFF
--- a/src/jquery.finger.js
+++ b/src/jquery.finger.js
@@ -69,6 +69,9 @@
 	}
 
 	function startHandler(event) {
+		if (event.which > 1)
+			return;
+		
 		var timeStamp = event.timeStamp || +new Date();
 
 		if (safeguard == timeStamp) return;


### PR DESCRIPTION
Right and middle clicks shouldn't be treated as taps (when using a desktop browser)

This should resolve issue #46 (thx to @giulianoriccio)